### PR TITLE
generate Stratego files into src-gen folder

### DIFF
--- a/org.metaborg.meta.lang.ts/trans/generate-instruct.str
+++ b/org.metaborg.meta.lang.ts/trans/generate-instruct.str
@@ -75,7 +75,7 @@ rules
     
   import-to-stratego:
     Import(t) -> 
-    $[[t].generated
+    $[src-gen/types/[t]
     ]
     where task := <nabl-collect-use-task> t
         ; <not(task-has-failed)> task

--- a/org.metaborg.meta.lang.ts/trans/typesystemlanguage.str
+++ b/org.metaborg.meta.lang.ts/trans/typesystemlanguage.str
@@ -96,8 +96,9 @@ rules // code generation
       task-setup(|project-path);
       index-setup(|<language>, project-path)
     with
-      filename := <guarantee-extension(|"generated.str")> path;
-      result   := <instruct-formulas; to-stratego(|project-path, <guarantee-extension(|"generated")> path)> selected
+      Module(modname, _) := ast;
+      filename := $[src-gen/types/[<guarantee-extension(|"str")> modname]];
+      result   := <instruct-formulas; to-stratego(|project-path, $[src-gen/types/[modname]])> selected
 
   // When given a tuple (path, string) this writes string into path.
   write-string-to-file =


### PR DESCRIPTION
I changed the compilation to generate Stratego files into `src-gen/types`. Names of imported TS files and module names are prefixed by `src-gen/types`. 
