### PR TITLE
Disambiguated syntax where type functions/rules could be seen as two imports

### DIFF
--- a/org.metaborg.meta.lang.ts/syntax/Module.sdf3
+++ b/org.metaborg.meta.lang.ts/syntax/Module.sdf3
@@ -17,6 +17,7 @@ lexical syntax
   ModuleID = {ModuleIDPart "/"}+ 
   ModuleIDPart = [a-zA-Z\.\_] [a-zA-Z0-9\'\.\-\_]* 
   ModuleID = "relations" {reject}
+  ModuleID = "type" {reject}
 
 lexical restrictions
 


### PR DESCRIPTION
Fixes [issue 16](http://yellowgrass.org/issue/TS/16)
