### PR TITLE
Added dynamic rule scope as suggested, fixes #14

### DIFF
--- a/org.metaborg.meta.lang.ts/trans/generate-instruct.str
+++ b/org.metaborg.meta.lang.ts/trans/generate-instruct.str
@@ -36,7 +36,8 @@ rules
       rules // projections
         [projection*]
     ]
-    where sectionD*   := <desugar-all> section*
+    where {| Projections:
+          sectionD*   := <desugar-all> section*
         ; sig*        := <collect(signature-to-stratego)> section*
         ; func*       := <collect(function-to-stratego)> section*
         ; rel*        := <collect(relation-to-stratego)> section*
@@ -56,7 +57,8 @@ rules
                ]
          else
            import := ""
-         end 
+         end
+         |} 
  
 rules
   


### PR DESCRIPTION
As suggested by @Gohla in a [comment](http://yellowgrass.org/issue/TS/14#showText7cda433f349e6c4b206854b237a2c015) on [issue 14](http://yellowgrass.org/issue/TS/14), adding a scope to the `Projections` dynamic rule keeps the code generation from generating superfluous rewrite projections. 
This fix is especially useful so you don't have to restart Eclipse if you wrote TS code that generated invalid Stratego in the projections (yes, this can happen atm). 
