### PR TITLE
Resolve ambiguity in relation definition syntax

### DIFF
--- a/org.metaborg.meta.lang.ts/syntax/common/Identifiers.sdf3
+++ b/org.metaborg.meta.lang.ts/syntax/common/Identifiers.sdf3
@@ -39,3 +39,4 @@ lexical syntax
   Keyword = "rules" 
   Keyword = "namespaces" 
   Keyword = "properties" 
+  Keyword = "define" 


### PR DESCRIPTION
If you have a `relations` section with plain relation definitions and then start another `relations` section, that syntax is ambiguous: 

``` ts
relations
  define <type:

relations
  a <eq: b
```

Parsed as something like:

```
amb([
  [ Relations([RelationDef([], "<type:")]), Relations([RelationUnCond(Var("a"),"<eq:",Var("b"))]) ]
, Relations([RelationUnCond(Var("define"), "<type:", Var("relations"))]),RelationUnCond(Var("a"),"<eq:",Var("b"))])
])
```

I've added `define` to the `Keyword` sort to resolve the ambiguity. 
