### PR TITLE
Add "else warning" construct to TS

### DIFF
--- a/org.metaborg.meta.lang.ts/syntax/TypeSystemLanguage.sdf3
+++ b/org.metaborg.meta.lang.ts/syntax/TypeSystemLanguage.sdf3
@@ -56,6 +56,10 @@ context-free syntax // formulas
     <Formula> else error <Term> on <Term>
   > {left} 
   
+  Formula.ElseWarning = <
+    <Formula> else warning <Term> on <Term>
+  > {left} 
+
   Formula.Not = <
     not <Formula>
   >
@@ -90,7 +94,7 @@ context-free syntax // instructions
     
 context-free priorities
 
-   Formula.Label > Formula.Not > Formula.Else > Formula.And > Formula.Or
+   Formula.Label > Formula.Not > Formula.Else > Formula.ElseWarning > Formula.And > Formula.Or
    
 context-free syntax // propositions
   

--- a/org.metaborg.meta.lang.ts/trans/generate-instruct.str
+++ b/org.metaborg.meta.lang.ts/trans/generate-instruct.str
@@ -248,6 +248,16 @@ rules // else error
     Id(Else(Return(VarRef(t)), msg, target), VarRef(d)) ->
       ${<task-create-error-on-failure(|ctx, {t}, {<term-to-stratego>msg}); task-create-id(|ctx, [{d}])> {<term-to-stratego>target}}
 
+rules // else warning
+
+  instruction-to-stratego :
+    I(ElseWarning(Return(VarRef(t)), msg, target)) ->
+      ${<task-create-warning-on-failure(|ctx, {t}, {<term-to-stratego>msg})> {<term-to-stratego>target}}
+
+  instruction-to-stratego :
+    Id(ElseWarning(Return(VarRef(t)), msg, target), VarRef(d)) ->
+      ${<task-create-warning-on-failure(|ctx, {t}, {<term-to-stratego>msg}); task-create-id(|ctx, [{d}])> {<term-to-stratego>target}}
+
 rules // attribute of
 
   // instruction-to-stratego :

--- a/org.metaborg.meta.lang.ts/trans/instructions.str
+++ b/org.metaborg.meta.lang.ts/trans/instructions.str
@@ -53,6 +53,10 @@ rules
       where Label(l, Is(is*)) := <instruct-formula(|dep)> form
 
   instruct-formula(|dep) :
+    ElseWarning(form, msg, target) -> Label(l, Is([is*, I(ElseWarning(Return(VarRef(l)), msg, target))]))
+      where Label(l, Is(is*)) := <instruct-formula(|dep)> form
+
+  instruct-formula(|dep) :
     form@Has(trm, op, Var(x)) -> Label(x, Is([Id(form, dep)]))
   
   instruct-formula(|dep) :

--- a/org.metaborg.meta.lang.ts/trans/label.str
+++ b/org.metaborg.meta.lang.ts/trans/label.str
@@ -34,6 +34,9 @@ rules
     Else(form, msg, target) -> Else(<label-formula>form, msg, target)
 
   label-formula :
+    ElseWarning(form, msg, target) -> ElseWarning(<label-formula>form, msg, target)
+
+  label-formula :
     form@Has(trm, op, Var(t)) -> Label(t, form)
         
   label-formula :


### PR DESCRIPTION
For the Green-Marl compiler, we sometimes want to give only warnings, not errors in a type rule. For example, we want allow implicit conversions between numerical types, but warn if they could incur a loss of precision (e.g. from `int` -> `float`). TS currently only gives an `else error "somestring"` construct, while we would like to have something like `else warning "somestring"`.

In this PR, I added syntax and codegen analog to the already existing `Else` AST node that allows one to write e.g. the following.

```
module test

relations

  define reflexive, transitive <permissive:
  define reflexive, transitive <:

  Int()  <: Long()

  a <permissive: b where a <: b
  // added to permit implicit numeric downcasts
  Long() <permissive: Int()

type rules

  // actual type rule with permissive subtype relation
  e@Add(e1, e2) : ty
  where e1 : t_e1 
    and e2 : t_e2 
    and ( t_e1 <permissive: t_e2 and t_e2 => ty
       or t_e2 <permissive: t_e1 and t_e1 => ty)
   else error "type mismatch" on e

  // warn on implicit conversions
  e@Add(esub, _) :-
  where e : ty
    and esub: t_esub
    and t_esub <: ty
   else warning "downcast" on esub
```

I talked to @guwac about it yesterday and he proposed that I just implement it and open a PR, since you guys have alot of other stuff to do probably ;)
